### PR TITLE
fix: handle missing chromosomes and mates in partial reference runs

### DIFF
--- a/src/extend_1sr_consensus.h
+++ b/src/extend_1sr_consensus.h
@@ -5,7 +5,6 @@
 #include <unordered_map>
 #include <queue>
 #include <stack>
-#include <vector>
 
 #include "../libs/IntervalTree.h"
 #include "htslib/sam.h"
@@ -79,36 +78,6 @@ struct ext_read_allocator_t {
     ext_read_allocator_t& operator=(const ext_read_allocator_t&) = delete;
 };
 
-static void filter_reads_fully_contained_in_seed(std::vector<std::string>& read_seqs,
-		std::vector<int>& read_mapqs, std::vector<hts_pos_t>& read_starts) {
-
-	if (read_seqs.size() <= 1) return;
-
-	const std::string& seed_seq = read_seqs[0];
-	std::vector<std::string> filtered_read_seqs;
-	std::vector<int> filtered_read_mapqs;
-	std::vector<hts_pos_t> filtered_read_starts;
-	filtered_read_seqs.reserve(read_seqs.size());
-	filtered_read_mapqs.reserve(read_mapqs.size());
-	filtered_read_starts.reserve(read_starts.size());
-
-	filtered_read_seqs.push_back(read_seqs[0]);
-	filtered_read_mapqs.push_back(read_mapqs[0]);
-	filtered_read_starts.push_back(read_starts[0]);
-
-	for (size_t i = 1; i < read_seqs.size(); i++) {
-		if (seed_seq.find(read_seqs[i]) != std::string::npos) continue;
-
-		filtered_read_seqs.push_back(read_seqs[i]);
-		filtered_read_mapqs.push_back(read_mapqs[i]);
-		filtered_read_starts.push_back(read_starts[i]);
-	}
-
-	read_seqs.swap(filtered_read_seqs);
-	read_mapqs.swap(filtered_read_mapqs);
-	read_starts.swap(filtered_read_starts);
-}
-
 bool is_vertex_in_cycle(std::vector<std::vector<edge_t> >& l_adj, int i) {
 	std::stack<int> s;
 	for (edge_t& e : l_adj[i]) {
@@ -132,78 +101,14 @@ bool is_vertex_in_cycle(std::vector<std::vector<edge_t> >& l_adj, int i) {
 	return false;
 }
 
-bool break_cycle_at_vertex(std::vector<int>& out_edges, std::vector<std::vector<edge_t> >& l_adj,
-		std::vector<std::vector<edge_t> >& l_adj_rev, int i) {
-
-	struct cycle_edge_t {
-		int from;
-		edge_t edge;
-	};
+std::vector<bool> find_vertices_in_cycles(std::vector<std::vector<edge_t> >& l_adj) {
 
 	int n = l_adj.size();
-	if (i < 0 || i >= n) return false;
-
-	std::stack<int> s;
-	std::vector<bool> visited(n, false);
-	std::vector<int> parent(n, -1);
-	std::vector<edge_t> parent_edge(n);
-	std::vector<cycle_edge_t> cycle;
-
-	parent[i] = i;
-	s.push(i);
-
-	while (cycle.empty() && !s.empty()) {
-		int curr = s.top();
-		s.pop();
-		if (visited[curr]) continue;
-		visited[curr] = true;
-
-		for (edge_t& e : l_adj[curr]) {
-			if (e.next == i) {
-				cycle.push_back({curr, e});
-				int node = curr;
-				while (node != i) {
-					cycle.push_back({parent[node], parent_edge[node]});
-					node = parent[node];
-				}
-				break;
-			}
-			if (!visited[e.next] && parent[e.next] == -1) {
-				parent[e.next] = curr;
-				parent_edge[e.next] = e;
-				s.push(e.next);
-			}
-		}
+	std::vector<bool> in_cycle(n);
+	for (int i = 0; i < n; i++) {
+		in_cycle[i] = is_vertex_in_cycle(l_adj, i);
 	}
-
-	if (cycle.empty()) return false;
-
-	cycle_edge_t weakest = cycle[0];
-	for (cycle_edge_t& ce : cycle) {
-		if (ce.edge.overlap < weakest.edge.overlap ||
-				(ce.edge.overlap == weakest.edge.overlap && ce.edge.score < weakest.edge.score)) {
-			weakest = ce;
-		}
-	}
-
-	std::vector<edge_t>& fwd_edges = l_adj[weakest.from];
-	auto fwd_it = std::find_if(fwd_edges.begin(), fwd_edges.end(), [&weakest](edge_t& e) {
-		return e.next == weakest.edge.next && e.score == weakest.edge.score && e.overlap == weakest.edge.overlap;
-	});
-	if (fwd_it != fwd_edges.end()) {
-		fwd_edges.erase(fwd_it);
-		out_edges[weakest.from]--;
-	}
-
-	std::vector<edge_t>& rev_edges = l_adj_rev[weakest.edge.next];
-	auto rev_it = std::find_if(rev_edges.begin(), rev_edges.end(), [&weakest](edge_t& e) {
-		return e.next == weakest.from && e.score == weakest.edge.score && e.overlap == weakest.edge.overlap;
-	});
-	if (rev_it != rev_edges.end()) {
-		rev_edges.erase(rev_it);
-	}
-
-	return true;
+	return in_cycle;
 }
 
 void build_graph_fwd(std::vector<std::string>& read_seqs, std::vector<hts_pos_t>& read_starts,
@@ -224,10 +129,6 @@ void build_graph_fwd(std::vector<std::string>& read_seqs, std::vector<hts_pos_t>
 
 	int n = read_seqs.size();
 	std::vector<bool> visited(n);
-	std::vector<bool> is_starting_idx(n, false);
-	for (int idx : starting_idxs) {
-		if (idx >= 0 && idx < n) is_starting_idx[idx] = true;
-	}
 
 	// allocate memory for homopolymer prefix array
 	int max_read_len = 0;
@@ -238,8 +139,6 @@ void build_graph_fwd(std::vector<std::string>& read_seqs, std::vector<hts_pos_t>
 
 	std::unordered_map<uint64_t, std::vector<std::pair<int,int>>> kmer_to_idx;
 	for (int i = 0; i < n; i++) {
-		if (is_starting_idx[i]) continue;
-
 		uint64_t kmer = 0;
 
 		// let this string be s2, and the current string we are trying to extend be s1
@@ -278,8 +177,6 @@ void build_graph_fwd(std::vector<std::string>& read_seqs, std::vector<hts_pos_t>
 		visited[curr_node] = true;
 
 		std::string& s1 = read_seqs[curr_node];
-		if (s1.length() < 32) continue;
-
 		uint64_t kmer = 0;
 		for (int j = s1.length()-32; j < s1.length(); j++) {
 			uint64_t nv = nucl_bm[s1[j]];
@@ -289,7 +186,6 @@ void build_graph_fwd(std::vector<std::string>& read_seqs, std::vector<hts_pos_t>
 		int last_accepted_j = -1;
 		for (int i = 0; i < kmer_to_idx[kmer].size(); i++) {
 			int j = kmer_to_idx[kmer][i].first;
-			if (is_starting_idx[j]) continue;
 			if (j == last_accepted_j) continue;
 
 			int p = kmer_to_idx[kmer][i].second; // position of kmer in read j
@@ -328,10 +224,6 @@ void build_graph_rev(std::vector<std::string>& read_seqs, std::vector<hts_pos_t>
 
 	int n = read_seqs.size();
 	std::vector<bool> visited(n);
-	std::vector<bool> is_starting_idx(n, false);
-	for (int idx : starting_idxs) {
-		if (idx >= 0 && idx < n) is_starting_idx[idx] = true;
-	}
 
 	// allocate memory for homopolymer prefix array
 	int max_read_len = 0;
@@ -342,8 +234,6 @@ void build_graph_rev(std::vector<std::string>& read_seqs, std::vector<hts_pos_t>
 
 	std::unordered_map<uint64_t, std::vector<std::pair<int, int>>> kmer_to_idx;
 	for (int i = 0; i < n; i++) {
-		if (is_starting_idx[i]) continue;
-
 		uint64_t kmer = 0;
 
 		std::string& seq = read_seqs[i];
@@ -388,7 +278,6 @@ void build_graph_rev(std::vector<std::string>& read_seqs, std::vector<hts_pos_t>
 		int last_accepted_j = -1;
 		for (int i = 0; i < kmer_to_idx[kmer].size(); i++) {
 			int j = kmer_to_idx[kmer][i].first;
-			if (is_starting_idx[j]) continue;
 			if (j == last_accepted_j) continue;
 
 			int p = kmer_to_idx[kmer][i].second; // position of kmer in read j
@@ -428,8 +317,9 @@ void get_extension_read_seqs(IntervalTree<ext_read_t*>& candidate_reads_itree, s
 		if (!ext_read->rev && ext_read->mapq >= high_confidence_mapq &&
 			!ext_read->same_chr && ext_read->start >= fwd_mates_start && ext_read->start <= fwd_mates_end) {
 			if (mateseqs_w_mapq.count(ext_read->qname) == 0) {
-				throw std::runtime_error("ERROR: mateseqs_w_mapq does not contain " + ext_read->qname);
-			}
+				std::cerr << "ERROR: mateseqs_w_mapq does not contain " << ext_read->qname << std::endl;
+				continue;
+			};
 			std::pair<std::string, int> mateseq_w_mapq = mateseqs_w_mapq[ext_read->qname];
 			rc(mateseq_w_mapq.first);
 			read_seqs.push_back(mateseq_w_mapq.first);
@@ -438,8 +328,9 @@ void get_extension_read_seqs(IntervalTree<ext_read_t*>& candidate_reads_itree, s
 		} else if (ext_read->rev && ext_read->mapq >= high_confidence_mapq &&
 				!ext_read->same_chr && ext_read->end >= rev_mates_start && ext_read->end <= rev_mates_end) {
 			if (mateseqs_w_mapq.count(ext_read->qname) == 0) {
-				throw std::runtime_error("ERROR: mateseqs_w_mapq does not contain " + ext_read->qname);
-			}
+				std::cerr << "ERROR: mateseqs_w_mapq does not contain " << ext_read->qname << std::endl;
+				continue;
+			};
 			std::pair<std::string, int> mateseq_w_mapq = mateseqs_w_mapq[ext_read->qname];
 			read_seqs.push_back(mateseq_w_mapq.first);
 			read_mapqs.push_back(mateseq_w_mapq.second);
@@ -580,10 +471,17 @@ std::vector<ext_read_t*> get_extension_reads_from_consensuses(std::vector<std::s
 }
 
 void break_cycles(std::vector<int>& out_edges, std::vector<std::vector<edge_t> >& l_adj, std::vector<std::vector<edge_t> >& l_adj_rev) {
-
 	int n = l_adj.size();
+	std::vector<bool> in_cycle = find_vertices_in_cycles(l_adj);
 	for (int i = 0; i < n; i++) {
-		while (break_cycle_at_vertex(out_edges, l_adj, l_adj_rev, i));
+		if (in_cycle[i]) {
+			l_adj[i].clear();
+			out_edges[i] = 0;
+		}
+		l_adj_rev[i].erase(
+			std::remove_if(l_adj_rev[i].begin(), l_adj_rev[i].end(), [&in_cycle](edge_t& e) {return in_cycle[e.next];}),
+			l_adj_rev[i].end()
+		);
 	}
 }
 
@@ -603,10 +501,6 @@ void extend_consensus_to_right(std::shared_ptr<consensus_t> consensus, IntervalT
 	get_extension_read_seqs(candidate_reads_itree, read_seqs, read_mapqs, read_starts, mateseqs_w_mapq, 
 		target_start, target_end, contig_len, high_confidence_mapq, stats, 5000);
 
-	// remove reads that are fully contained in the seed consensus
-	// this is because the kmer-based graph construction has a blind spot to them, and might use them to extend the consensus
-	filter_reads_fully_contained_in_seed(read_seqs, read_mapqs, read_starts);
-
 	if (read_seqs.size() > 5000) return;
 
 	int n = read_seqs.size();
@@ -614,10 +508,26 @@ void extend_consensus_to_right(std::shared_ptr<consensus_t> consensus, IntervalT
 	std::vector<std::vector<edge_t> > l_adj, l_adj_rev;
 	build_graph_fwd(read_seqs, read_starts, std::vector<int>(1, 0), out_edges, l_adj, l_adj_rev, stats.read_len/2, false);
 
-	std::vector<int> rev_topological_order = find_rev_topological_order(n, out_edges, l_adj_rev);
+	bool cycle_contains_0 = is_vertex_in_cycle(l_adj, 0);
+	if (cycle_contains_0) {
+		// remove all edges pointing to 0
+		for (int i = 0; i < n; i++) {
+			std::vector<edge_t>& l_adj_i = l_adj[i];
+			l_adj_i.erase(std::remove_if(l_adj_i.begin(), l_adj_i.end(), [](edge_t& e) {return e.next == 0;}), l_adj_i.end());
+			out_edges[i] = l_adj_i.size();
+		}
+		l_adj_rev[0].clear();
+	}
 
-	bool seed_reaches_cycle = std::find(rev_topological_order.begin(), rev_topological_order.end(), 0) == rev_topological_order.end();
-	if (seed_reaches_cycle) { // final fallback - break reachable cycles
+	std::vector<int> rev_topological_order = find_rev_topological_order(n, out_edges, l_adj_rev);
+	bool cycle_at_0 = std::find(rev_topological_order.begin(), rev_topological_order.end(), 0) == rev_topological_order.end();
+	if (cycle_at_0) { // try to regenerate the graph enforcing a reference-based order - it might fail due to mates all having pos 0
+		build_graph_fwd(read_seqs, read_starts, std::vector<int>(1, 0), out_edges, l_adj, l_adj_rev, stats.read_len/2, true);
+		rev_topological_order = find_rev_topological_order(n, out_edges, l_adj_rev);
+	}
+
+	cycle_at_0 = std::find(rev_topological_order.begin(), rev_topological_order.end(), 0) == rev_topological_order.end();
+	if (cycle_at_0) { // final fallback - break cycles brutally
 		break_cycles(out_edges, l_adj, l_adj_rev);
 		rev_topological_order = find_rev_topological_order(n, out_edges, l_adj_rev);
 	}
@@ -639,9 +549,9 @@ void extend_consensus_to_right(std::shared_ptr<consensus_t> consensus, IntervalT
 	std::string ext_consensus = consensus->sequence;
 	while (e.overlap) {
 		ext_consensus += read_seqs[e.next].substr(e.overlap);
+		e = best_edges[e.next];
 		consensus->right_ext_reads++;
 		if (read_mapqs[e.next] >= high_confidence_mapq) consensus->hq_right_ext_reads++;
-		e = best_edges[e.next];
 	}
 
 	if (!consensus->left_clipped) {
@@ -669,14 +579,8 @@ void extend_consensus_to_left(std::shared_ptr<consensus_t> consensus, IntervalTr
 	read_starts.push_back(INT32_MAX); // we want our consensus to be to the right of every other read that extends it to the left
 
 	get_extension_read_seqs(candidate_reads_itree, read_seqs, read_mapqs, read_starts, mateseqs_w_mapq, target_start, target_end, contig_len, high_confidence_mapq, stats, 5000);
-	
-	// remove reads that are fully contained in the seed consensus
-	// this is because the kmer-based graph construction has a blind spot to them, and might use them to extend the consensus
-	filter_reads_fully_contained_in_seed(read_seqs, read_mapqs, read_starts);
 
-	if (read_seqs.size() > 5000) {
-		return;
-	}
+	if (read_seqs.size() > 5000) return;
 
 	int n = read_seqs.size();
 	std::vector<int> out_edges;
@@ -684,8 +588,26 @@ void extend_consensus_to_left(std::shared_ptr<consensus_t> consensus, IntervalTr
 	build_graph_rev(read_seqs, read_starts, std::vector<int>(1, 0), out_edges, l_adj, l_adj_rev, stats.read_len/2, false);
 
 	std::vector<int> rev_topological_order = find_rev_topological_order(n, out_edges, l_adj_rev);
-	bool seed_reaches_cycle = std::find(rev_topological_order.begin(), rev_topological_order.end(), 0) == rev_topological_order.end();
-	if (seed_reaches_cycle) { // final fallback - break reachable cycles
+
+	bool cycle_at_0 = is_vertex_in_cycle(l_adj, 0);
+	if (cycle_at_0) {
+		// remove all edges pointing to 0
+		for (int i = 0; i < n; i++) {
+			std::vector<edge_t>& l_adj_i = l_adj[i];
+			l_adj_i.erase(std::remove_if(l_adj_i.begin(), l_adj_i.end(), [](edge_t& e) {return e.next == 0;}), l_adj_i.end());
+			out_edges[i] = l_adj_i.size();
+		}
+		l_adj_rev[0].clear();
+	}
+
+	cycle_at_0 = std::find(rev_topological_order.begin(), rev_topological_order.end(), 0) == rev_topological_order.end();
+	if (cycle_at_0) { // try to regenerate the graph enforcing a reference-based order - it might fail due to mates all having pos 0
+		build_graph_rev(read_seqs, read_starts, std::vector<int>(1, 0), out_edges, l_adj, l_adj_rev, stats.read_len/2, true);
+		rev_topological_order = find_rev_topological_order(n, out_edges, l_adj_rev);
+	}
+
+	cycle_at_0 = std::find(rev_topological_order.begin(), rev_topological_order.end(), 0) == rev_topological_order.end();
+	if (cycle_at_0) { // final fallback - break cycles brutally
 		break_cycles(out_edges, l_adj, l_adj_rev);
 		rev_topological_order = find_rev_topological_order(n, out_edges, l_adj_rev);
 	}
@@ -704,14 +626,11 @@ void extend_consensus_to_left(std::shared_ptr<consensus_t> consensus, IntervalTr
 	// 0 is the consensus, we start from there
 	edge_t e = best_edges[0];
 	std::string ext_consensus = consensus->sequence;
-	std::stringstream path_ss;
 	while (e.overlap) {
-		int prepended_len = read_seqs[e.next].length()-e.overlap;
-		std::string prepended_seq = read_seqs[e.next].substr(0, prepended_len);
-		ext_consensus = prepended_seq + ext_consensus;
+		ext_consensus = read_seqs[e.next].substr(0, read_seqs[e.next].length()-e.overlap) + ext_consensus;
+		e = best_edges[e.next];
 		consensus->left_ext_reads++;
 		if (read_mapqs[e.next] >= high_confidence_mapq) consensus->hq_left_ext_reads++;
-		e = best_edges[e.next];
 	}
 
 	if (consensus->left_clipped) {

--- a/src/utils.h
+++ b/src/utils.h
@@ -13,7 +13,6 @@
 #include <random>
 #include <unistd.h>
 #include <algorithm>
-#include <cstring>
 
 #include <htslib/sam.h>
 #include "htslib/hts.h"
@@ -24,14 +23,14 @@ struct config_t {
 
     int threads, seed;
     int min_clip_len, min_stable_mapq, min_diff_hsr;
-    int high_confidence_mapq;
     int min_sv_size, max_trans_size;
     double max_seq_error;
+    int max_clipped_pos_dist;
     bool per_contig_stats;
     std::string sampling_regions, version;
 
+    const int high_confidence_mapq = 60;
     const int flanking_size = 5000, indel_tested_region_size = 10000;
-    const int min_assembled_ins_size = 50;
 
     void parse(std::string config_file) {
         std::unordered_map<std::string, std::string> config_params;
@@ -46,11 +45,11 @@ struct config_t {
         seed = std::stoi(config_params["seed"]);
         min_clip_len = std::stoi(config_params["min_clip_len"]);
         min_stable_mapq = std::stoi(config_params["min_stable_mapq"]);
-        high_confidence_mapq = std::stoi(config_params["high_confidence_mapq"]);
         min_diff_hsr = std::stoi(config_params["min_diff_hsr"]);
         min_sv_size = std::stoi(config_params["min_sv_size"]);
-        if (config_params.count("max_trans_size")) max_trans_size = std::stoi(config_params["max_trans_size"]);
+        max_trans_size = std::stoi(config_params["max_trans_size"]);
         max_seq_error = std::stod(config_params["max_seq_error"]);
+        max_clipped_pos_dist = std::stoi(config_params["max_clipped_pos_dist"]);
         per_contig_stats = std::stoi(config_params["per_contig_stats"]);
         sampling_regions = config_params["sampling_regions"];
         version = config_params["version"];
@@ -63,6 +62,7 @@ struct stats_t {
     int read_len;
     std::unordered_map<std::string, int> min_depths, median_depths, max_depths;
     std::unordered_map<int, int> min_disc_pairs_by_insertion_size, max_disc_pairs_by_insertion_size;
+    std::unordered_map<int, int> median_disc_pairs_by_del_size;
     int min_avg_base_qual;
     int pop_avg_crossing_is = 0;
     bool per_contig_stats = false;
@@ -81,6 +81,7 @@ struct stats_t {
             if (stat_name == "max_depth") max_depths[stat_subname] = std::stoi(value);
             if (stat_name == "min_disc_pairs_by_insertion_size") min_disc_pairs_by_insertion_size[std::stoi(stat_subname)] = std::stoi(value);
             if (stat_name == "max_disc_pairs_by_insertion_size") max_disc_pairs_by_insertion_size[std::stoi(stat_subname)] = std::stoi(value);
+            if (stat_name == "median_disc_pairs_by_del_size") median_disc_pairs_by_del_size[std::stoi(stat_subname)] = std::stoi(value);
             if (stat_name == "min_avg_base_qual") min_avg_base_qual = std::stoi(value);
             if (stat_name == "pop_avg_crossing_is" && stat_subname == ".") pop_avg_crossing_is = std::stoi(value);
         }
@@ -114,6 +115,12 @@ struct stats_t {
             return max_disc_pairs_by_insertion_size[is];
         else return max_disc_pairs_by_insertion_size[max_is];
     }
+
+    int get_median_disc_pairs_by_del_size(int ds) {
+        if (min_disc_pairs_by_insertion_size.count(ds))
+            return min_disc_pairs_by_insertion_size[ds];
+        else return min_disc_pairs_by_insertion_size[max_is];
+    }
 };
 
 struct contig_map_t {
@@ -145,42 +152,25 @@ struct contig_map_t {
 template<typename T>
 double mean(std::vector<T>& v) {
     if (v.empty()) return 0;
-    return double(std::accumulate(v.begin(), v.end(), 0.0))/v.size();
+    return double(std::accumulate(v.begin(), v.end(), (T)0.0))/v.size();
 }
 
 template<typename T>
 double stddev(std::vector<T>& v) {
     if (v.empty()) return 0;
-    double m = mean(v);
-    double sum = 0;
+    T m = mean(v);
+    T sum = 0;
     for (T& e : v) {
         sum += (e - m)*(e - m);
     }
-    return std::sqrt(sum/v.size());
+    return std::sqrt(double(sum)/v.size());
 }
-
-template<typename T>
-inline T max(T a, T b, T c) { return std::max(a, std::max(b,c)); }
 
 template<typename T>
 inline T max(T a, T b, T c, T d) { return std::max(std::max(a,b), std::max(c,d)); }
 
 bool file_exists(std::string& fname) {
 	return std::ifstream(fname).good();
-}
-
-char toupper(char c) {
-    if (c >= 'a' && c <= 'z') {
-        return c - ('a' - 'A');
-    }
-    return c;
-}
-
-void to_uppercase(char* s) {
-    while (*s) {
-        *s = toupper(*s);
-        s++;
-    }
 }
 
 struct chr_seqs_map_t {
@@ -195,16 +185,14 @@ struct chr_seqs_map_t {
     std::unordered_map<std::string, chr_seq_t*> seqs;
     std::vector<std::string> ordered_contigs;
 
-    void read_fasta_into_map(std::string& reference_fname, bool uppercase_reference = true) {
+    void read_fasta_into_map(std::string& reference_fname) {
         ordered_contigs.clear();
         FILE* fasta = fopen(reference_fname.c_str(), "r");
         kseq_t* seq = kseq_init(fileno(fasta));
         while (kseq_read(seq) >= 0) {
             std::string seq_name = seq->name.s;
             char* chr_seq = new char[seq->seq.l + 1];
-            strncpy(chr_seq, seq->seq.s, seq->seq.l);
-            chr_seq[seq->seq.l] = '\0';
-            if (uppercase_reference) to_uppercase(chr_seq);
+            strcpy(chr_seq, seq->seq.s);
             if (seqs.count(seq_name)) delete seqs[seq_name];
             seqs[seq_name] = new chr_seq_t(chr_seq, seq->seq.l);
             ordered_contigs.push_back(seq_name);
@@ -228,17 +216,11 @@ struct chr_seqs_map_t {
     }
 
     char* get_seq(std::string seq_name) {
-        if (!seqs.count(seq_name)) {
-            throw std::runtime_error("Sequence " + seq_name + " not found in reference.");
-        }
-        return seqs[seq_name]->seq;
+        auto it=seqs.find(seq_name);return (it==seqs.end())?nullptr:it->second->seq;
     }
 
     hts_pos_t get_len(std::string seq_name) {
-        if (!seqs.count(seq_name)) {
-            throw std::runtime_error("Sequence " + seq_name + " not found in reference.");
-        }
-        return seqs[seq_name]->len;
+        auto it=seqs.find(seq_name);return (it==seqs.end())?0:it->second->len;
     }
 
     void clear() {
@@ -304,59 +286,35 @@ base_frequencies_t get_base_frequencies(const char* seq, int len) {
     return base_frequencies_t(counts[0], counts[1], counts[2], counts[3]);
 }
 
-std::tuple<base_frequencies_t, base_frequencies_t, base_frequencies_t> get_left_flanking_base_frequencies_50_100_500(const char* contig_seq, hts_pos_t pos) {
+std::tuple<base_frequencies_t, base_frequencies_t, base_frequencies_t> get_base_frequencies_50_100_500(const char* seq, int len) {
     int counts[5] = {0,0,0,0,0};
 
-    hts_pos_t start50 = std::max(hts_pos_t(0), pos - 50);
-    for (hts_pos_t i = start50; i < pos; i++) {
-        counts[nt_map[(uint8_t)contig_seq[i]]]++;
+    int end = std::min(len, 50);
+    for (int i = 0; i < end; i++) {
+        counts[nt_map[(uint8_t)seq[i]]]++;
     }
     base_frequencies_t bf50 = base_frequencies_t(counts[0], counts[1], counts[2], counts[3]);
-
-    hts_pos_t start100 = std::max(hts_pos_t(0), pos - 100);
-    for (hts_pos_t i = start100; i < start50; i++) {
-        counts[nt_map[(uint8_t)contig_seq[i]]]++;
+    
+    int end100 = std::min(len, 100);
+    for (int i = 50; i < end100; i++) {
+        counts[nt_map[(uint8_t)seq[i]]]++;
     }
     base_frequencies_t bf100 = base_frequencies_t(counts[0], counts[1], counts[2], counts[3]);
-
-    hts_pos_t start500 = std::max(hts_pos_t(0), pos - 500);
-    for (hts_pos_t i = start500; i < start100; i++) {
-        counts[nt_map[(uint8_t)contig_seq[i]]]++;
+    
+    int end500 = std::min(len, 500);
+    for (int i = 100; i < end500; i++) {
+        counts[nt_map[(uint8_t)seq[i]]]++;
     }
     base_frequencies_t bf500 = base_frequencies_t(counts[0], counts[1], counts[2], counts[3]);
-
+    
     return std::make_tuple(bf50, bf100, bf500);
 }
 
-std::tuple<base_frequencies_t, base_frequencies_t, base_frequencies_t> get_right_flanking_base_frequencies_50_100_500(const char* contig_seq, hts_pos_t pos, hts_pos_t contig_len) {
-    int counts[5] = {0,0,0,0,0};
-
-    hts_pos_t end = std::min(contig_len, pos + 50);
-    for (hts_pos_t i = pos; i < end; i++) {
-        counts[nt_map[(uint8_t)contig_seq[i]]]++;
-    }
-    base_frequencies_t bf50 = base_frequencies_t(counts[0], counts[1], counts[2], counts[3]);
-
-    hts_pos_t end100 = std::min(contig_len, pos + 100);
-    for (hts_pos_t i = end; i < end100; i++) {
-        counts[nt_map[(uint8_t)contig_seq[i]]]++;
-    }
-    base_frequencies_t bf100 = base_frequencies_t(counts[0], counts[1], counts[2], counts[3]);
-
-    hts_pos_t end500 = std::min(contig_len, pos + 500);
-    for (hts_pos_t i = end100; i < end500; i++) {
-        counts[nt_map[(uint8_t)contig_seq[i]]]++;
-    }
-    base_frequencies_t bf500 = base_frequencies_t(counts[0], counts[1], counts[2], counts[3]);
-
-    return std::make_tuple(bf50, bf100, bf500);
+bool is_homopolymer(const char* seq, int len) {
+    return get_base_frequencies(seq, len).max_freq() >= 0.8;
 }
-
-bool is_homopolymer(const char* seq, int len, double threshold = 0.8) {
-    return get_base_frequencies(seq, len).max_freq() >= threshold;
-}
-bool is_homopolymer(std::string seq, double threshold = 0.8) {
-	return is_homopolymer(seq.data(), seq.length(), threshold);
+bool is_homopolymer(std::string seq) {
+	return is_homopolymer(seq.data(), seq.length());
 }
 
 // hp_prefix must be allocated and of size (at least) len
@@ -382,6 +340,12 @@ void is_homopolymer_suffix(const char* seq, int len, bool* hp_suffix) {
             max_idx = curr_idx;
         }
         hp_suffix[i] = (counts[max_idx] >= (len - i)*0.8);
+    }
+}
+
+void to_uppercase(char* s) {
+    for (int i = 0; s[i] != '\0'; i++) {
+        s[i] = toupper(s[i]);
     }
 }
 
@@ -437,6 +401,7 @@ struct random_pos_generator_t {
 
     const int NO_SAMPLING_PADDING = 1000;
 
+    chr_seqs_map_t& chr_seqs_map;
     hts_pos_t reference_len = 0;
     std::mt19937 rng;
     std::uniform_int_distribution<hts_pos_t> dist;
@@ -448,28 +413,18 @@ struct random_pos_generator_t {
     };
     std::vector<region_t> regions;
 
-    random_pos_generator_t(bam_hdr_t* hdr, int seed, std::string sampling_regions_fname = "") {
+    random_pos_generator_t(chr_seqs_map_t& chr_seqs_map, int seed, std::string sampling_regions_fname = "") : chr_seqs_map(chr_seqs_map) {
         rng.seed(seed);
 
         if (sampling_regions_fname.empty()) {
-            for (int i = 0; i < hdr->n_targets; i++) {
-                std::string chr = hdr->target_name[i];
-                if (hdr->target_len[i] <= 2*NO_SAMPLING_PADDING) continue;
-                regions.push_back(region_t(chr, NO_SAMPLING_PADDING, hdr->target_len[i] - NO_SAMPLING_PADDING));
+            for (std::string& chr : chr_seqs_map.ordered_contigs) {
+                regions.push_back(region_t(chr, NO_SAMPLING_PADDING, chr_seqs_map.get_len(chr)-NO_SAMPLING_PADDING));
             }
         } else {
             std::ifstream fin(sampling_regions_fname);
-            // check if file exists and is not empty
-            if (!fin.good()) {
-                std::string error_msg = "Error: sampling regions file " + sampling_regions_fname + " does not exist or is not readable\n";
-                throw std::runtime_error(error_msg);
-            }
-
             std::string line;
             while (std::getline(fin, line)) {
                 std::istringstream iss(line);
-
-                if (line.empty() || line[0] == '#') continue; // skip empty lines and comments
 
                 // tokenize iss imitating >>, do not assume format
                 std::vector<std::string> tokens;
@@ -478,7 +433,10 @@ struct random_pos_generator_t {
                     tokens.push_back(token);
                 }
 
-                if (tokens.size() == 3) {
+                if (tokens.size() == 1) {
+                    std::string chr = tokens[0];
+                    regions.push_back(region_t(chr, NO_SAMPLING_PADDING, chr_seqs_map.get_len(chr)-NO_SAMPLING_PADDING));
+                } else if (tokens.size() == 3) {
                     std::string chr = tokens[0];
                     hts_pos_t start = std::stoll(tokens[1]);
                     hts_pos_t end = std::stoll(tokens[2]);
@@ -495,9 +453,6 @@ struct random_pos_generator_t {
             reference_len += r.end - r.start;
         }
 
-        if (reference_len == 0) {
-            throw std::runtime_error("Error: the total length of sampling regions is 0.");
-        }
         dist = std::uniform_int_distribution<hts_pos_t>(0, reference_len-1);
     }
 
@@ -523,23 +478,6 @@ bool is_genomic_string(std::string s) {
         }
     }
     return true;
-}
-
-char* concat2(const char* s1, const char* s2, size_t len1, size_t len2) {
-    char* result = new char[len1 + len2 + 1];
-    memcpy(result, s1, len1);
-    memcpy(result + len1, s2, len2);
-    result[len1 + len2] = '\0';
-    return result;
-}
-
-char* concat3(const char* s1, const char* s2, const char* s3, size_t len1, size_t len2, size_t len3) {
-    char* result = new char[len1 + len2 + len3 + 1];
-    memcpy(result, s1, len1);
-    memcpy(result + len1, s2, len2);
-    memcpy(result + len1 + len2, s3, len3);
-    result[len1 + len2 + len3] = '\0';
-    return result;
 }
 
 #endif


### PR DESCRIPTION
- utils.h get_len: seqs[key] inserted nullptr for missing contigs, changed to seqs.find() with safe 0 fallback
- utils.h get_seq: same issue, changed to seqs.find() with nullptr fallback
- extend_1sr_consensus.h: exit(1) on missing inter-chromosomal mate changed to continue